### PR TITLE
Add Colorado license to about page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -21,9 +21,10 @@ body_class: page page-about
     <div class="flex-1">
       <h3 class="text-xl font-heading text-brand-green mb-2">Licensure</h3>
       <ul class="list-[circle] list-inside mb-6 space-y-1 text-body">
-        <li>Licensed Clinical Social Worker (IL and FL)</li>
+        <li>Licensed Clinical Social Worker (IL, FL, CO)</li>
         <li>IL License number 149.024139</li>
         <li>FL license number SW24290</li>
+        <li>CO license number CSW.09933539</li>
       </ul>
 
       <h3 class="text-xl font-heading text-brand-green mb-2">Education</h3>


### PR DESCRIPTION
Updates the Licensure section on the about page:

- Changes "Licensed Clinical Social Worker (IL and FL)" to "(IL, FL, CO)"
- Adds bullet: "CO license number CSW.09933539"

Ran `npm run build` per README — no changes to `assets/css/style.css` (no new utility classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)